### PR TITLE
Fixed issue where get_all_keys or _get_occurence choked on strings.

### DIFF
--- a/nested_lookup/nested_lookup.py
+++ b/nested_lookup/nested_lookup.py
@@ -49,16 +49,17 @@ def get_all_keys(dictionary):
     result_list = []
 
     def recrusion(dictionary):
-        for key, value in iteritems(dictionary):
-            if isinstance(value, dict):
-                result_list.append(key)
-                recrusion(dictionary=value)
-            elif isinstance(value, list):
-                result_list.append(key)
-                for list_items in value:
-                    recrusion(dictionary=list_items)
-            else:
-                result_list.append(key)
+        if hasattr(dictionary, 'items'):
+            for key, value in iteritems(dictionary):
+                if isinstance(value, dict):
+                    result_list.append(key)
+                    recrusion(dictionary=value)
+                elif isinstance(value, list):
+                    result_list.append(key)
+                    for list_items in value:
+                        recrusion(dictionary=list_items)
+                else:
+                    result_list.append(key)
 
     recrusion(dictionary=dictionary)
     return result_list
@@ -104,16 +105,17 @@ def _get_occurrence(dictionary, item, keyword):
     occurrence = [0]
 
     def recrusion(dictionary):
-        if item == 'key':
-            occurrence[0] += 1 if dictionary.get(keyword) else 0
-        elif keyword in dictionary.values():
-            occurrence[0] += dictionary.values().count(keyword)
-        for key, value in iteritems(dictionary):
-            if isinstance(value, dict):
-                recrusion(dictionary=value)
-            elif isinstance(value, list):
-                for list_items in value:
-                    recrusion(dictionary=list_items)
+        if hasattr(dictionary, 'items'):
+            if item == 'key':
+                occurrence[0] += 1 if dictionary.get(keyword) else 0
+            elif keyword in dictionary.values():
+                occurrence[0] += dictionary.values().count(keyword)
+            for key, value in iteritems(dictionary):
+                if isinstance(value, dict):
+                    recrusion(dictionary=value)
+                elif isinstance(value, list):
+                    for list_items in value:
+                        recrusion(dictionary=list_items)
 
     recrusion(dictionary=dictionary)
     return occurrence[0]

--- a/test_nested_loopkup.py
+++ b/test_nested_loopkup.py
@@ -184,6 +184,25 @@ class TestGetAllKeys(TestCase):
                 "memory": "16 GB",
             }
         }
+        self.sample4 = {
+            "values": [
+                {
+                    "checks": [
+                        {
+                            "monitoring_zones": [
+                                "mzdfw",
+                                "mzfra",
+                                "mzhkg",
+                                "mziad",
+                                "mzlon",
+                                "mzord",
+                                "mzsyd"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
 
     def test_sample_data1(self):
         result = get_all_keys(self.sample1)
@@ -221,6 +240,16 @@ class TestGetAllKeys(TestCase):
         ]
         for key in keys_to_verify:
             self.assertIn(key, result)
+
+    def test_sample_data4(self):
+        result = get_all_keys(self.sample4)
+        self.assertEqual(3, len(result))
+        keys_to_verify = [
+            "values",
+            "checks",
+            "monitoring_zones"
+        ]
+        for key in keys_to_verify:
 
 
 class TestGetOccurrence(TestCase):


### PR DESCRIPTION
Found a bug when trying to utilize get_occurence_of_key and get_all_keys on a data structure similar to this:

>          self.sample4 = {
>             "values": [
>                 {
>                     "checks": [
>                         {
>                             "monitoring_zones": [
>                                 "mzdfw",
>                                 "mzfra",
>                                 "mzhkg",
>                                 "mziad",
>                                 "mzlon",
>                                 "mzord",
>                                 "mzsyd"
>                             ]
>                         }
>                     ]
>                 }
>             ]
>         }

I've added a test to the test_nested_lookup file that shows the error in question, but for ease, this is what is returned when the test is run without the fix:

> python -m unittest test_nested_loopkup
> ...E...........
> ======================================================================
> ERROR: test_sample_data4 (test_nested_loopkup.TestGetAllKeys)
> ----------------------------------------------------------------------
> Traceback (most recent call last):
>   File "test_nested_loopkup.py", line 245, in test_sample_data4
>   File "nested_lookup/nested_lookup.py", line 63, in get_all_keys
>     recrusion(dictionary=dictionary)
>   File "nested_lookup/nested_lookup.py", line 59, in recrusion
>     recrusion(dictionary=list_items)
>   File "nested_lookup/nested_lookup.py", line 59, in recrusion
>     recrusion(dictionary=list_items)
>   File "nested_lookup/nested_lookup.py", line 59, in recrusion
>     recrusion(dictionary=list_items)
>   File "nested_lookup/nested_lookup.py", line 52, in recrusion
>     for key, value in iteritems(dictionary):
>   File "/Users/jpavlav/Projects/nested-lookup/venv2/lib/python2.7/site-packages/six.py", line 605, in iteritems
>     return d.iteritems(**kw)
> AttributeError: 'str' object has no attribute 'iteritems'
> 
> ----------------------------------------------------------------------
> Ran 15 tests in 0.001s
> 
> FAILED (errors=1)

The fix implemented in nested_lookup.py works for both python3 and python2.