### PR TITLE
Fix for issue #19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.7"
 # command to install dependencies
 install:
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.7"
   - "3.6"
-  - "3.7"
 # command to install dependencies
 install:
   - pip install .

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 nested_lookup
 #############
 
-.. image:: https://img.shields.io/badge/pypi-0.2.13-green.svg
+.. image:: https://img.shields.io/badge/pypi-0.2.14-green.svg
   :target: https://pypi.python.org/pypi/nested-lookup
 .. image:: https://travis-ci.org/rameshrvr/nested-lookup.svg?branch=master
   :target: https://travis-ci.org/rameshrvr/nested-lookup

--- a/nested_lookup/lookup_api.py
+++ b/nested_lookup/lookup_api.py
@@ -4,13 +4,13 @@ from six import iteritems
 from nested_lookup import nested_lookup
 
 
-def nested_delete(document, key: str, in_place: bool = False):
+def nested_delete(document, key, in_place=False):
     if not in_place:
         document = copy.deepcopy(document)
     return _nested_delete(document=document, key=key)
 
 
-def _nested_delete(document, key: str) -> dict:
+def _nested_delete(document, key):
     """
     Method to delete a key->value pair from a nested document
     Args:
@@ -31,9 +31,9 @@ def _nested_delete(document, key: str) -> dict:
     return document
 
 
-def nested_update(document, key: str, value: object,
-                  in_place: bool = False,
-                  treat_as_element: bool = True):
+def nested_update(
+    document, key, value, in_place=False, treat_as_element=True
+):
     """
     Method to update a key->value pair in a nested document
     Args:
@@ -74,8 +74,9 @@ def nested_update(document, key: str, value: object,
                           val_len=val_len)
 
 
-def _nested_update(document, key: str, value: object,
-                   val_len: int, run: int = 0):
+def _nested_update(
+    document, key, value, val_len, run=0
+):
     """
     Method to update a key->value pair in a nested document
     Args:
@@ -113,9 +114,10 @@ def _nested_update(document, key: str, value: object,
     return document
 
 
-def nested_alter(document, key: str, callback_function=None,
-                 function_parameters: list = None, conversion_function=None,
-                 wild_alter: bool = False, in_place: bool = True):
+def nested_alter(
+    document, key, callback_function=None, function_parameters=None,
+    conversion_function=None, wild_alter=False, in_place=True
+):
     """
     Method to alter all values of the occurences of the key "key".
     The provided callback_function is used to alter the scalar values
@@ -134,7 +136,7 @@ def nested_alter(document, key: str, callback_function=None,
             "callback_function"
         wild_alter: Find matching elements via wild-match by the given keys
             and alter those.
-            HINT: Keep in mind that the wild-match might return unexpected types!
+        HINT: Keep in mind that the wild-match might return unexpected types!
         in_place (bool):
             True: modify the dict in place;
             False: create a deep copy of the dict and modify it
@@ -161,8 +163,10 @@ def nested_alter(document, key: str, callback_function=None,
                          in_place=in_place, key_len=key_len)
 
 
-def _call_callback(value_list: list, callback_function,
-                   function_parameters: list, conversion_function):
+def _call_callback(
+    value_list, callback_function, function_parameters,
+    conversion_function
+):
     """
     internal helper to call the callback function
     """
@@ -183,9 +187,10 @@ def _call_callback(value_list: list, callback_function,
     return return_list
 
 
-def _nested_alter(document, keys, callback_function,
-                  function_parameters: list, conversion_function,
-                  wild_alter: bool, in_place: bool, key_len: int):
+def _nested_alter(
+    document, keys, callback_function, function_parameters,
+    conversion_function, wild_alter, in_place, key_len
+):
     """
     """
     # return data if no callback_function is provided
@@ -196,7 +201,9 @@ def _nested_alter(document, keys, callback_function,
     # iterate over all given keys in the list
     for key in keys:
         # try to find the key:
-        findings = nested_lookup(key, document, with_keys=True, wild=wild_alter)
+        findings = nested_lookup(
+            key, document, with_keys=True, wild=wild_alter
+        )
         for k, v in findings.items():
             trans_val = _call_callback(v, callback_function,
                                        function_parameters,

--- a/nested_lookup/nested_lookup.py
+++ b/nested_lookup/nested_lookup.py
@@ -54,21 +54,17 @@ def get_all_keys(dictionary):
     """
     result_list = []
 
-    def recrusion(dictionary):
-        for key, value in iteritems(dictionary):
-            if isinstance(value, dict):
+    def recrusion(document):
+        if isinstance(document, list):
+            for list_items in document:
+                recrusion(document=list_items)
+        elif isinstance(document, dict):
+            for key, value in iteritems(document):
                 result_list.append(key)
-                recrusion(dictionary=value)
-            elif isinstance(value, list):
-                result_list.append(key)
-                for list_items in value:
-                    # Make sure the items inside the list is iterable
-                    if hasattr(list_items, 'items'):
-                        recrusion(dictionary=list_items)
-            else:
-                result_list.append(key)
+                recrusion(document=value)
+        return
 
-    recrusion(dictionary=dictionary)
+    recrusion(document=dictionary)
     return result_list
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='nested-lookup',
-    version='0.2.13',
+    version='0.2.14',
     description='Python functions for working with deeply nested documents (lists and dicts) ',
     keywords='nested document dictionary dict list lookup schema json xml yaml',
     long_description=open('README.rst').read(),

--- a/test_nested_lookup.py
+++ b/test_nested_lookup.py
@@ -193,6 +193,16 @@ class TestGetAllKeys(TestCase):
                 }]
             }]
         }
+        self.sample5 = [{
+            "listings": [{
+                "name": "title",
+                "postcode": "postcode",
+                "full_address": "fulladdress",
+                "city": "city",
+                "lat": "latitude",
+                "lng": "longitude"
+            }]
+        }]
 
     def test_sample_data1(self):
         result = get_all_keys(self.sample1)
@@ -238,6 +248,16 @@ class TestGetAllKeys(TestCase):
             "values",
             "checks",
             "monitoring_zones"
+        ]
+        for key in keys_to_verify:
+            self.assertIn(key, result)
+
+    def test_sample_data5(self):
+        result = get_all_keys(self.sample5)
+        self.assertEqual(7, len(result))
+        keys_to_verify = [
+            'listings', 'name', 'postcode', 'full_address', 'city',
+            'lat', 'lng'
         ]
         for key in keys_to_verify:
             self.assertIn(key, result)


### PR DESCRIPTION
Unittest results on python 2 & 3

```
M281649SBH03Q:nested-lookup ramesh_rv$ python -m unittest test_nested_lookup test_lookup_api
..............................................
----------------------------------------------------------------------
Ran 46 tests in 0.005s

OK
M281649SBH03Q:nested-lookup ramesh_rv$ pytest
================================================================= test session starts =================================================================
platform darwin -- Python 3.7.0, pytest-4.5.0, py-1.8.0, pluggy-0.11.0
rootdir: /Users/ramesh_rv/Documents/Github/python_packages/nested-lookup
collected 46 items                                                                                                                                    

test_lookup_api.py ............................                                                                                                 [ 60%]
test_nested_lookup.py ..................                                                                                                        [100%]

============================================================== 46 passed in 0.11 seconds ==============================================================
```

CI results:
<img width="1353" alt="Screen Shot 2019-05-13 at 1 03 24 PM" src="https://user-images.githubusercontent.com/28801292/57603502-87bb3480-757f-11e9-8750-f16128d3bd57.png">
