### PR TITLE
Fix wrong-ordered update

### DIFF
--- a/nested_lookup/lookup_api.py
+++ b/nested_lookup/lookup_api.py
@@ -65,34 +65,27 @@ def nested_update(document, key, value, in_place=False, treat_as_element=True):
     elif treat_as_element:
         value = [value]
 
-    val_len = len(value)
-
     if not in_place:
         document = copy.deepcopy(document)
-    return _nested_update(document=document, key=key, value=value, val_len=val_len)
+    return _nested_update(document=document, key=key, value=value)
 
 
-def _nested_update(document, key, value, val_len, run=0):
+def _nested_update(document, key, value):
     """
-    Method to update a key->value pair in a nested document
+    Method to update a key->value pair in a nested document. If values count less than
+    keys count, then uses last value as default.
     Args:
         document: Might be List of Dicts (or) Dict of Lists (or)
             Dict of List of Dicts etc...
         key (str): Key to update the value
         value (list): value(s) which should be used for replacement purpouse
-        val_len (int): lenght of the value element
-        run (int): holds the number of findings for the given key.
-            Every time the key is found, run = run + 1. If the list value[run]
-            exists,
-            the corresponding element is used for replacement purpouse.
-            Defaults to 0.
     Return:
         Returns a document that has updated key, value pair.
     """
     if isinstance(document, list):
         for list_items in document:
             _nested_update(
-                document=list_items, key=key, value=value, val_len=val_len, run=run
+                document=list_items, key=key, value=value
             )
     elif isinstance(document, dict):
         for dict_key, dict_value in iteritems(document):
@@ -101,7 +94,7 @@ def _nested_update(document, key, value, val_len, run=0):
                 if len(value) > 1:
                     value.pop(0)
             _nested_update(
-                document=dict_value, key=key, value=value, val_len=val_len, run=run
+                document=dict_value, key=key, value=value
             )
     return document
 

--- a/nested_lookup/lookup_api.py
+++ b/nested_lookup/lookup_api.py
@@ -60,7 +60,7 @@ def nested_update(document, key, value, in_place=False, treat_as_element=True):
     # check the length of the list and provide it to _nested_update
     if not treat_as_element and not isinstance(value, list):
         raise Exception(
-            "You need to pass value as list if you opt for" + "this feature"
+            "The value must be a list when treat_as_element is False."
         )
     elif treat_as_element:
         value = [value]
@@ -106,7 +106,7 @@ def nested_alter(
     function_parameters=None,
     conversion_function=None,
     wild_alter=False,
-    in_place=True,
+    in_place=False,
 ):
     """
     Method to alter all values of the occurences of the key "key".
@@ -190,8 +190,7 @@ def _nested_alter(
     in_place,
     key_len,
 ):
-    """
-    """
+
     # return data if no callback_function is provided
     if callback_function is None:
         warnings.warn("Please provide a callback_function to nested_alter().")

--- a/nested_lookup/lookup_api.py
+++ b/nested_lookup/lookup_api.py
@@ -95,17 +95,11 @@ def _nested_update(document, key, value, val_len, run=0):
                 document=list_items, key=key, value=value, val_len=val_len, run=run
             )
     elif isinstance(document, dict):
-        if document.get(key):
-            # check if a value with the coresponding index exists and
-            # use it otherwise recycle the intially given value
-            if run < val_len:
-                val = value[run]
-            else:
-                run = 0
-                val = value[run]
-            document[key] = val
-            run = run + 1
         for dict_key, dict_value in iteritems(document):
+            if dict_key == key:
+                document[key] = value[0]
+                if len(value) > 1:
+                    value.pop(0)
             _nested_update(
                 document=dict_value, key=key, value=value, val_len=val_len, run=run
             )

--- a/nested_lookup/lookup_api.py
+++ b/nested_lookup/lookup_api.py
@@ -72,8 +72,9 @@ def nested_update(document, key, value, in_place=False, treat_as_element=True):
 
 def _nested_update(document, key, value):
     """
-    Method to update a key->value pair in a nested document. If values count less than
-    keys count, then uses last value as default.
+    Method to update a key->value pair in a nested document.
+    If the number of passed values is less than the number of key matches
+    when scanning for updates, use last value as default.
     Args:
         document: Might be List of Dicts (or) Dict of Lists (or)
             Dict of List of Dicts etc...

--- a/test_lookup_api.py
+++ b/test_lookup_api.py
@@ -311,7 +311,7 @@ class TestNestedUpdate(BaseLookUpApi):
         # if you need to adress a list of dicts, you have to
         # manually iterate over those and pass them to nested_update
         # one by one
-        self.assertNotEqual(updated_document[1]["salsa"][0]["burrito"]["taco"], 200)
+        self.assertEqual(updated_document[1]["salsa"][0]["burrito"]["taco"], 200)
 
     def test_nested_update_raise_error(self):
         doc = self.sample_data4
@@ -552,6 +552,18 @@ class TestNestedAlter(BaseLookUpApi):
         self.assertEqual(out[0]["taco"], 52)
         self.assertEqual(out[1]["salsa"][0]["burrito"]["taco"], 79)
 
+    def test_nested_alter_work_with_right_order(self):
+        document = {"taco": 42, "salsa": [{"burrito":{"key":20}}], "key":50}
+
+        def callback(data):
+            return data + 100
+
+        altered_document = nested_alter(document, "key", callback, in_place=True)
+        
+        self.assertEqual(altered_document["salsa"][0]["burrito"]["key"], 120)
+        self.assertEqual(altered_document["key"], 150)
+
+        
     def test_sample_data4(self):
 
         result = {


### PR DESCRIPTION
Hi all, I found a little bug:
when I try to alter this json structure:
```json
{
  "total": 1,
  "data": [{
    "id": "2015-001-093555-258",
    "regDate": "2015-12-22T08:49:29",
    "history": [{
      "id": "2015-001-093555-258",
      "regDate": "2015-12-22T08:49:29",
      "type": "CREATION",
      "link": "/api/search/history/2015-001-093555-258/0?key=306411c9-44c9-4239-a97c-17745368f224"
    }],
    "link": "/api/search/extract/2015-001-093555-258?key=306411c9-44c9-4239-a97c-17745368f224"
  }],
  "key": "306411c9-44c9-4239-a97c-17745368f224"
}
``` 
code:
```python
with open("test.json", "rb") as file:
    struc = json.loads(file.read())
    alter = nested_alter(struc, "link", lambda v: v + "###")
    print(alter)
```
I've got this output:
```json
{
  "total": 1,
  "data": [{
    "id": "2015-001-093555-258",
    "regDate": "2015-12-22T08:49:29",
    "history": [{
      "id": "2015-001-093555-258",
      "regDate": "2015-12-22T08:49:29",
      "type": "CREATION",
      "link": "/api/search/extract/2015-001-093555-258?key=306411c9-44c9-4239-a97c-17745368f224###"
    }],
    "link": "/api/search/history/2015-001-093555-258/0?key=306411c9-44c9-4239-a97c-17745368f224###"
  }],
  "key": "306411c9-44c9-4239-a97c-17745368f224"
}
```
As you can see, values are reversed.

The problem was in ```if document.get(key):``` function. Key link detects in wrong order:

```python
{
  "total": 1,
  "data": [{
    "id": "2015-001-093555-258",
    "regDate": "2015-12-22T08:49:29",
    "history": [{
      "id": "2015-001-093555-258",
      "regDate": "2015-12-22T08:49:29",
      "type": "CREATION",
      "link <- SECOND DETECT": "/api/search/history/2015-001-093555-258/0?key=306411c9-44c9-4239-a97c-17745368f224"
    }],
    "link  <- FIRST DETECT": "/api/search/extract/2015-001-093555-258?key=306411c9-44c9-4239-a97c-17745368f224"
  }],
  "key": "306411c9-44c9-4239-a97c-17745368f224"
}
```
So, I decided to use current key ```dict_key == key```  for update instead of  ```document.get()```

------------------------------------

Also, I suggest using stack-like values list, instead of ```run``` variable. If ```len(value)``` less than
    keys count, then use the last value as default.
```python
if dict_key == key:
    document[key] = value[0]
    if len(value) > 1:
        value.pop(0)
```
-------------------------------------
And in conclusion, I haven't understood, why the test, ```test_nested_update_taco_for_example()``` should change only first value?