### PR TITLE
[Improvement] New function - occurrences and values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nested_lookup.egg-info/*
 .cache
 .vscode
 git_commit.sh
+venv

--- a/nested_lookup/__init__.py
+++ b/nested_lookup/__init__.py
@@ -3,5 +3,6 @@ from .nested_lookup import (
     get_all_keys,
     get_occurrence_of_key,
     get_occurrence_of_value,
+    get_occurrence_of_value_with_self_value
 )
 from .lookup_api import nested_update, nested_delete, nested_alter

--- a/nested_lookup/__init__.py
+++ b/nested_lookup/__init__.py
@@ -3,6 +3,6 @@ from .nested_lookup import (
     get_all_keys,
     get_occurrence_of_key,
     get_occurrence_of_value,
-    get_occurrence_of_value_with_self_value
+    get_occurrences_and_values
 )
 from .lookup_api import nested_update, nested_delete, nested_alter

--- a/nested_lookup/nested_lookup.py
+++ b/nested_lookup/nested_lookup.py
@@ -83,7 +83,7 @@ def get_occurrence_of_key(dictionary, key):
     return _get_occurrence(dictionary=dictionary, item="key", keyword=key)
 
 
-def get_occurrence_of_value_with_self_value(items: list, value: any) -> dict:
+def get_occurrences_and_values(items: list, value: any) -> dict:
     """
     Method to get occurrence of a value in a nested list of dictionary
 
@@ -116,7 +116,7 @@ def get_occurrence_of_value_with_self_value(items: list, value: any) -> dict:
 def _get_occurrence_with_values(dictionary, item, keyword):
     occurrence = [0]
 
-    result_recursion = recursion(dictionary, item, keyword, occurrence, True)
+    result_recursion = _recursion(dictionary, item, keyword, occurrence, True)
 
     global values_list
     values_list = []
@@ -137,7 +137,7 @@ def get_occurrence_of_value(dictionary, value):
     return _get_occurrence(dictionary=dictionary, item="value", keyword=value)
 
 
-def recursion(dictionary, item, keyword, occurrence, with_values=False):
+def _recursion(dictionary, item, keyword, occurrence, with_values=False):
 
     global values_list
 
@@ -150,11 +150,11 @@ def recursion(dictionary, item, keyword, occurrence, with_values=False):
             values_list.append(dictionary)
     for key, value in iteritems(dictionary):
         if isinstance(value, dict):
-            recursion(value, item, keyword, occurrence, with_values)
+            _recursion(value, item, keyword, occurrence, with_values)
         elif isinstance(value, list):
             for list_items in value:
                 if hasattr(list_items, "items"):
-                    recursion(list_items, item, keyword, occurrence, with_values)
+                    _recursion(list_items, item, keyword, occurrence, with_values)
                 elif list_items == keyword:
                     occurrence[0] += 1 if item == "value" else 0
 
@@ -174,7 +174,7 @@ def _get_occurrence(dictionary, item, keyword):
         Number of occurrence of the given keyword in the dict
     """
     occurrence = [0]
-    recursion(dictionary, item, keyword, occurrence)
+    _recursion(dictionary, item, keyword, occurrence)
 
     global values_list
     values_list = []

--- a/nested_lookup/nested_lookup.py
+++ b/nested_lookup/nested_lookup.py
@@ -3,6 +3,9 @@ from six import iteritems
 from collections import defaultdict
 
 
+values_list = []
+
+
 def nested_lookup(key, document, wild=False, with_keys=False):
     """Lookup a key in a nested document, return a list of values"""
     if with_keys:
@@ -80,6 +83,47 @@ def get_occurrence_of_key(dictionary, key):
     return _get_occurrence(dictionary=dictionary, item="key", keyword=key)
 
 
+def get_occurrence_of_value_with_self_value(items: list, value: any) -> dict:
+    """
+    Method to get occurrence of a value in a nested list of dictionary
+
+    Args:
+        items: list of dictionary: Nested dictionary
+        value: Value to search for the occurrences
+
+    Return:
+        Dict where the key is the value arg and his value is a new
+        dict with occurrences and values
+    """
+    occurrences = {}
+    occurrence = 0
+    value_list = []
+
+    for item in items:
+        occurrence_result, values = _get_occurrence_with_values(dictionary=item, item="value", keyword=value)
+        occurrence = occurrence + occurrence_result
+        if occurrence_result:
+            value_list.extend(values)
+
+    occurrences[value] = {
+        'occurrences': occurrence,
+        'values': value_list
+    }
+
+    return occurrences
+
+
+def _get_occurrence_with_values(dictionary, item, keyword):
+    occurrence = [0]
+
+    result_recursion = recursion(dictionary, item, keyword, occurrence, True)
+
+    global values_list
+    values_list = []
+
+    return occurrence[0], result_recursion
+
+
 def get_occurrence_of_value(dictionary, value):
     """
     Method to get occurrence of a value in a nested dictionary
@@ -91,6 +135,31 @@ def get_occurrence_of_value(dictionary, value):
         Number of occurrence (Integer)
     """
     return _get_occurrence(dictionary=dictionary, item="value", keyword=value)
+
+
+def recursion(dictionary, item, keyword, occurrence, with_values=False):
+
+    global values_list
+
+    if item == "key":
+        if dictionary.get(keyword) is not None:
+            occurrence[0] += 1
+    elif keyword in list(dictionary.values()):
+        occurrence[0] += list(dictionary.values()).count(keyword)
+        if with_values:
+            values_list.append(dictionary)
+    for key, value in iteritems(dictionary):
+        if isinstance(value, dict):
+            recursion(value, item, keyword, occurrence, with_values)
+        elif isinstance(value, list):
+            for list_items in value:
+                if hasattr(list_items, "items"):
+                    recursion(list_items, item, keyword, occurrence, with_values)
+                elif list_items == keyword:
+                    occurrence[0] += 1 if item == "value" else 0
+
+    if values_list:
+        return values_list
 
 
 def _get_occurrence(dictionary, item, keyword):
@@ -105,22 +174,9 @@ def _get_occurrence(dictionary, item, keyword):
         Number of occurrence of the given keyword in the dict
     """
     occurrence = [0]
+    recursion(dictionary, item, keyword, occurrence)
 
-    def recrusion(dictionary):
-        if item == "key":
-            if dictionary.get(keyword) is not None:
-                occurrence[0] += 1
-        elif keyword in list(dictionary.values()):
-            occurrence[0] += list(dictionary.values()).count(keyword)
-        for key, value in iteritems(dictionary):
-            if isinstance(value, dict):
-                recrusion(dictionary=value)
-            elif isinstance(value, list):
-                for list_items in value:
-                    if hasattr(list_items, "items"):
-                        recrusion(dictionary=list_items)
-                    elif list_items == keyword:
-                        occurrence[0] += 1 if item == "value" else 0
+    global values_list
+    values_list = []
 
-    recrusion(dictionary=dictionary)
     return occurrence[0]

--- a/test_nested_lookup.py
+++ b/test_nested_lookup.py
@@ -5,6 +5,7 @@ from nested_lookup import (
     get_all_keys,
     get_occurrence_of_key,
     get_occurrence_of_value,
+    get_occurrence_of_value_with_self_value
 )
 
 
@@ -349,6 +350,36 @@ class TestGetOccurrence(TestCase):
             }
         }
 
+        self.sample6 = [
+            {
+                "processor_name": "4",
+                "processor_speed": "2.7 GHz",
+                "core_details": {
+                    "total_numberof_cores": "4",
+                    "l2_cache(per_core)": "256 KB",
+                }
+            }
+        ]
+
+        self.sample7 = [
+            {
+                "processor_name": "4",
+                "processor_speed": "2.7 GHz",
+                "core_details": {
+                    "total_numberof_cores": "4",
+                    "l2_cache(per_core)": "256 KB",
+                }
+            },
+            {
+                "processor_name": "4",
+                "processor_speed": "2.7 GHz",
+                "core_details": {
+                    "total_numberof_cores": "4",
+                    "l2_cache(per_core)": "256 KB",
+                }
+            }
+        ]
+
     def test_sample_data1(self):
         result = get_occurrence_of_key(self.sample1, "build_version")
         self.assertEqual(4, result)
@@ -384,6 +415,30 @@ class TestGetOccurrence(TestCase):
         # Add key 'memory' and verify
         self.sample5["memory"] = 0
         self.assertEqual(2, get_occurrence_of_key(self.sample5, "memory"))
+
+    def test_sample_data6(self):
+        value = '4'
+        result = get_occurrence_of_value_with_self_value(self.sample6, value)
+        self.assertEqual(2, result[value]['occurrences'])
+        self.assertEqual(2, len(result[value]['values']))
+
+    def test_sample_data7(self):
+        value = '2.7 GHz'
+        result = get_occurrence_of_value_with_self_value(self.sample6, value)
+        self.assertEqual(1, result[value]['occurrences'])
+        self.assertEqual(1, len(result[value]['values']))
+
+    def test_sample_data8(self):
+        value = '4'
+        result = get_occurrence_of_value_with_self_value(self.sample7, value)
+        self.assertEqual(4, result[value]['occurrences'])
+        self.assertEqual(4, len(result[value]['values']))
+
+    def test_sample_data9(self):
+        value = '5'
+        result = get_occurrence_of_value_with_self_value(self.sample7, value)
+        self.assertEqual(0, result[value]['occurrences'])
+        self.assertEqual(0, len(result[value]['values']))
 
 
 if __name__ == "__main__":

--- a/test_nested_lookup.py
+++ b/test_nested_lookup.py
@@ -5,7 +5,7 @@ from nested_lookup import (
     get_all_keys,
     get_occurrence_of_key,
     get_occurrence_of_value,
-    get_occurrence_of_value_with_self_value
+    get_occurrences_and_values
 )
 
 
@@ -418,25 +418,25 @@ class TestGetOccurrence(TestCase):
 
     def test_sample_data6(self):
         value = '4'
-        result = get_occurrence_of_value_with_self_value(self.sample6, value)
+        result = get_occurrences_and_values(self.sample6, value)
         self.assertEqual(2, result[value]['occurrences'])
         self.assertEqual(2, len(result[value]['values']))
 
     def test_sample_data7(self):
         value = '2.7 GHz'
-        result = get_occurrence_of_value_with_self_value(self.sample6, value)
+        result = get_occurrences_and_values(self.sample6, value)
         self.assertEqual(1, result[value]['occurrences'])
         self.assertEqual(1, len(result[value]['values']))
 
     def test_sample_data8(self):
         value = '4'
-        result = get_occurrence_of_value_with_self_value(self.sample7, value)
+        result = get_occurrences_and_values(self.sample7, value)
         self.assertEqual(4, result[value]['occurrences'])
         self.assertEqual(4, len(result[value]['values']))
 
     def test_sample_data9(self):
         value = '5'
-        result = get_occurrence_of_value_with_self_value(self.sample7, value)
+        result = get_occurrences_and_values(self.sample7, value)
         self.assertEqual(0, result[value]['occurrences'])
         self.assertEqual(0, len(result[value]['values']))
 


### PR DESCRIPTION
This is an amazing library and I've had missing of one thing. Is not possible recovery the elements when you to use `get_occurrence_of_value` function.

Thinking about it, I wrote a new function that do this: `get_occurrences_and_values`

Dict return:

- **Key**: The searched value
- **Value**: Dict with occurrences count and values of each occurrence 

```
{
    '2.7 GHz': {
    'occurrences': 1,
    'values': [
        {
            'processor_name': '4',
            'processor_speed': '2.7 GHz',
            'core_details': {
                'total_numberof_cores': '4',
                'l2_cache(per_core)': '256 KB'
            }
        }
        ]
    }
}
```