### PR TITLE
Updated my_document to dict from a tuple

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ For example, given the following document:
         "EMAIL_RECOVERY" : "test3@example.com",
         "email_address" : "test4@example.com",
      },
- },
+ }
 
 Next, we could act ``wild`` and find all the email addresses like this:
 


### PR DESCRIPTION
The current my_document has a hanging comma, which would prevent it
from rendering properly in the example cases provided by the README.

```
>>> my_document = {
... "name" : "Rocko Ballestrini",
... "email_address" : "test1@example.com",
... "other" : {
...     "secondary_email" : "test2@example.com",
...     "EMAIL_RECOVERY" : "test3@example.com",
...     "email_address" : "test4@example.com",
...     },
... },
>>> type(my_document)
<class 'tuple'>
>>> my_document = {
... "name" : "Rocko Ballestrini",
... "email_address" : "test1@example.com",
... "other" : {
...     "secondary_email" : "test2@example.com",
...     "EMAIL_RECOVERY" : "test3@example.com",
...     "email_address" : "test4@example.com",
...     },
... }
>>> type(my_document)
<class 'dict'>
>>> 
```